### PR TITLE
カーソルが変なところに飛ぶバグを消した

### DIFF
--- a/lib/edit.ts
+++ b/lib/edit.ts
@@ -4,6 +4,7 @@ import { getLineCount } from "./node.ts";
 import { range } from "./range.ts";
 import { textInput } from "./dom.ts";
 import { isArray, isNumber, isString } from "../utils.ts";
+import { sleep } from "./sleep.ts";
 
 export function undo(count = 1) {
   for (const _ of range(0, count)) {
@@ -136,7 +137,7 @@ export function downBlocks(count = 1) {
   }
 }
 
-export function insertText(text: string) {
+export async function insertText(text: string) {
   const cursor = textInput();
   if (!cursor) {
     throw Error("#text-input is not ditected.");
@@ -147,5 +148,5 @@ export function insertText(text: string) {
   const uiEvent = document.createEvent("UIEvent");
   uiEvent.initEvent("input", true, false);
   cursor.dispatchEvent(uiEvent);
-  return Promise.resolve();
+  await sleep(1); // 待ち時間は感覚で決めた
 }

--- a/lib/pointer.ts
+++ b/lib/pointer.ts
@@ -69,5 +69,5 @@ export async function mimicHoldDown(
   element.dispatchEvent(new TouchEvent("touchend", mouseOptions));
   element.dispatchEvent(new MouseEvent("click", mouseOptions));
 
-  await Promise.resolve();
+  await sleep(10); // 待ち時間は感覚で決めた
 }

--- a/mod.ts
+++ b/mod.ts
@@ -45,7 +45,7 @@ export async function addTask() {
 
   // カーソル行の下に書き込む
   await insertLine(
-    (linePos ?? 0) + 1,
+    linePos + 1,
     toString({ title: "", base, plan, record: {} }),
   );
 }
@@ -92,8 +92,8 @@ export async function startTask() {
 
   // 開始時刻をtoggleする
   await replaceLines(
-    linePos ?? 0,
-    linePos ?? 0,
+    linePos,
+    linePos,
     toString({
       record: { start: !start ? new Date() : undefined },
       ...rest,
@@ -115,8 +115,8 @@ export async function endTask() {
 
   // 終了時刻をtoggleする
   await replaceLines(
-    linePos ?? 0,
-    linePos ?? 0,
+    linePos,
+    linePos,
     toString({
       record: { start, end: !end ? new Date() : undefined },
       ...rest,
@@ -152,8 +152,8 @@ export async function toggleTask() {
 
   // すでに終了しているタスクは未開始に戻す
   await replaceLines(
-    linePos ?? 0,
-    linePos ?? 0,
+    linePos,
+    linePos,
     toString({
       record: {},
       ...rest,
@@ -193,8 +193,8 @@ export async function posterioriEndTask() {
   // 上書きする
   const now = new Date();
   await replaceLines(
-    linePos ?? 0,
-    linePos ?? 0,
+    linePos,
+    linePos,
     toString({
       record: { start: prevEnd ?? now, end: now },
       ...rest,

--- a/mod.ts
+++ b/mod.ts
@@ -51,8 +51,10 @@ export async function addTask() {
 }
 
 function getModifyRange() {
-  const { selectionRange: { start, end } } = caret();
-  return [start.line, end.line] as const;
+  const { selectionRange: { start, end }, selectedText, position } = caret();
+  return selectedText === ""
+    ? [position.line, position.line]
+    : [start.line, end.line] as const;
 }
 
 /** カーソル行もしくは選択範囲内の全てのタスクの日付を進める


### PR DESCRIPTION
close [⬜insertLine()がmobile版scrapboxで変な挙動をする](https://scrapbox.io/takker/⬜insertLine()がmobile版scrapboxで変な挙動をする) and [🏃moveToday()を複数回実行するとカーソルがタイトルに吹っ飛ぶ](https://scrapbox.io/takker/🏃moveToday()を複数回実行するとカーソルがタイトルに吹っ飛ぶ)