### PR TITLE
The unit of `duration` is seconds, not minutes

### DIFF
--- a/parseSpecifier.test.ts
+++ b/parseSpecifier.test.ts
@@ -49,12 +49,12 @@ Deno.test("parseSpecifier()", async (t) => {
       [
         "タスクの名前 s:09:37 d:45",
         new Date(2022, 0, 1, 9, 37),
-        45,
+        45 * 60,
       ],
       [
         "タスクの名前 d:40 s:09:37",
         new Date(2022, 0, 1, 9, 37),
-        40,
+        40 * 60,
       ],
       [
         "タスクの名前 s:T23",
@@ -108,7 +108,7 @@ Deno.test("parseSpecifier()", async (t) => {
   await t.step("only duration", () => {
     assertEquals<SpecifierResult | undefined>(
       parseSpecifier("  タスクの名前 d:753", new Date()),
-      { name: "  タスクの名前", duration: 753 },
+      { name: "  タスクの名前", duration: 753 * 60 },
     );
   });
 });

--- a/parseSpecifier.ts
+++ b/parseSpecifier.ts
@@ -26,7 +26,7 @@ export function parseSpecifier(
     [, name, duration] = parts;
     return {
       name: name.trimEnd(),
-      duration: parseInt(duration),
+      duration: parseInt(duration) * 60,
     };
   } else {
     return;
@@ -42,7 +42,9 @@ export function parseSpecifier(
       return {
         name: name.trimEnd(),
         start: date,
-        ...(duration !== undefined ? { duration: parseInt(duration) } : {}),
+        ...(duration !== undefined
+          ? { duration: parseInt(duration) * 60 }
+          : {}),
       };
     }
     return {
@@ -51,7 +53,7 @@ export function parseSpecifier(
         base.getTime() / 1000,
         (date.getTime() - base.getTime()) / (24 * 60 * 60 * 1000),
       ),
-      ...(duration !== undefined ? { duration: parseInt(duration) } : {}),
+      ...(duration !== undefined ? { duration: parseInt(duration) * 60 } : {}),
     };
   }
 }


### PR DESCRIPTION
close [✅開始日時指定記法の見積時間の書き込みがバグっている](https://scrapbox.io/takker/✅開始日時指定記法の見積時間の書き込みがバグっている)