### PR TITLE
Move library

### DIFF
--- a/commands/format.ts
+++ b/commands/format.ts
@@ -1,6 +1,5 @@
 import { format as formatPage } from "../diary.ts";
-import { joinPageRoom } from "../deps/scrapbox.ts";
-import { useStatusBar } from "../deps/scrapbox-std.ts";
+import { joinPageRoom, useStatusBar } from "../deps/scrapbox-std.ts";
 
 /** タスクページをformatする
  *

--- a/commands/format.ts
+++ b/commands/format.ts
@@ -1,5 +1,6 @@
 import { format as formatPage } from "../diary.ts";
-import { joinPageRoom, useStatusBar } from "../deps/scrapbox-std.ts";
+import { useStatusBar } from "../deps/scrapbox-std.ts";
+import { joinPageRoom } from "../deps/scrapbox-websocket.ts";
 
 /** タスクページをformatする
  *

--- a/commands/makePlan.ts
+++ b/commands/makePlan.ts
@@ -1,7 +1,8 @@
 import { toTitle } from "../diary.ts";
 import { isSameDay } from "../deps/date-fns.ts";
 import { makeDiaryPages } from "../plan.ts";
-import { openInTheSameTab, patch } from "../deps/scrapbox-std.ts";
+import { openInTheSameTab } from "../deps/scrapbox-std.ts";
+import { patch } from "../deps/scrapbox-websocket.ts";
 import type { Scrapbox } from "../deps/scrapbox.ts";
 declare const scrapbox: Scrapbox;
 

--- a/commands/makePlan.ts
+++ b/commands/makePlan.ts
@@ -1,8 +1,7 @@
 import { toTitle } from "../diary.ts";
 import { isSameDay } from "../deps/date-fns.ts";
 import { makeDiaryPages } from "../plan.ts";
-import { joinPageRoom } from "../deps/scrapbox.ts";
-import { openInTheSameTab } from "../deps/scrapbox-std.ts";
+import { openInTheSameTab, patch } from "../deps/scrapbox-std.ts";
 import type { Scrapbox } from "../deps/scrapbox.ts";
 declare const scrapbox: Scrapbox;
 
@@ -14,11 +13,13 @@ declare const scrapbox: Scrapbox;
  * @param project 日付ページを作成するproject
  */
 export async function* makePlan(dates: Iterable<Date>, project: string) {
-  // backgroundでページを作成する
+  // backgroundでページを追記作成する
   for await (const { lines } of makeDiaryPages(dates)) {
-    const { insert, cleanup } = await joinPageRoom(project, lines[0]);
-    await insert(lines.slice(1).join("\n"), "_end");
-    cleanup();
+    await patch(
+      project,
+      lines[0],
+      (oldLines) => [...oldLines.map((line) => line.text), ...lines.slice(1)],
+    );
     yield { message: `Created "/${project}/${lines[0]}"`, lines };
   }
 

--- a/commands/transport.ts
+++ b/commands/transport.ts
@@ -4,7 +4,8 @@ import { parseBlock, parseLines, TaskBlock, toString } from "../task.ts";
 import { isString } from "../utils.ts";
 import { isSameDay } from "../deps/date-fns.ts";
 import { getPage } from "../deps/scrapbox.ts";
-import { joinPageRoom, sleep, useStatusBar } from "../deps/scrapbox-std.ts";
+import { sleep, useStatusBar } from "../deps/scrapbox-std.ts";
+import { joinPageRoom } from "../deps/scrapbox-websocket.ts";
 
 export interface TransportProps {
   /** ここで指定したページからタスクを転送する */

--- a/commands/transport.ts
+++ b/commands/transport.ts
@@ -3,8 +3,8 @@ import { toDate } from "../diary.ts";
 import { parseBlock, parseLines, TaskBlock, toString } from "../task.ts";
 import { isString } from "../utils.ts";
 import { isSameDay } from "../deps/date-fns.ts";
-import { getPage, joinPageRoom } from "../deps/scrapbox.ts";
-import { sleep, useStatusBar } from "../deps/scrapbox-std.ts";
+import { getPage } from "../deps/scrapbox.ts";
+import { joinPageRoom, sleep, useStatusBar } from "../deps/scrapbox-std.ts";
 
 export interface TransportProps {
   /** ここで指定したページからタスクを転送する */

--- a/commands/transport.ts
+++ b/commands/transport.ts
@@ -21,10 +21,10 @@ export async function transport(
 ) {
   const result = await getPage(project, title);
   if (!result.ok) {
-    throw result;
+    throw result.value;
   }
   const date = toDate(title);
-  const { lines } = result;
+  const { lines } = result.value;
 
   // 日付ページの場合は、その日付と一致しないタスクを転送する
   // 日付ベージでなければ、全てのタスクを転送する

--- a/deps/scrapbox-std.ts
+++ b/deps/scrapbox-std.ts
@@ -4,7 +4,9 @@ export {
   getLines,
   getText,
   insertLine,
+  joinPageRoom,
   openInTheSameTab,
+  patch,
   replaceLines,
   useStatusBar,
 } from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/mod.ts";

--- a/deps/scrapbox-std.ts
+++ b/deps/scrapbox-std.ts
@@ -1,18 +1,18 @@
 export {
   caret,
-  encodeTitleURI,
   getLines,
   getText,
   insertLine,
-  joinPageRoom,
   openInTheSameTab,
-  patch,
   replaceLines,
   useStatusBar,
-} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/mod.ts";
-export {
-  getIndentLineCount,
-} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/text.ts";
+} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/browser/dom/mod.ts";
 export {
   sleep,
-} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/sleep.ts";
+} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/sleep.ts";
+export {
+  getIndentLineCount,
+} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/text.ts";
+export {
+  encodeTitleURI,
+} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/title.ts";

--- a/deps/scrapbox-websocket.ts
+++ b/deps/scrapbox-websocket.ts
@@ -1,0 +1,4 @@
+export {
+  joinPageRoom,
+  patch,
+} from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/browser/websocket/mod.ts";

--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -3,6 +3,6 @@ import type {
   PageList,
   Scrapbox,
 } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.0.8/mod.ts";
-export { getPage } from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/rest/pages.ts";
+export { getPage } from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.5/rest/pages.ts";
 export type Line = Page["lines"][0];
 export type { PageList, Scrapbox };

--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -4,6 +4,5 @@ import type {
   Scrapbox,
 } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.0.8/mod.ts";
 export { getPage } from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.8.4/rest/pages.ts";
-export { joinPageRoom } from "https://raw.githubusercontent.com/takker99/scrapbox-headless-script/0.3.1/mod.ts";
 export type Line = Page["lines"][0];
 export type { PageList, Scrapbox };

--- a/pushTasks.ts
+++ b/pushTasks.ts
@@ -2,7 +2,7 @@ import { TaskBlock, toString } from "./task.ts";
 import { format, toTitle } from "./diary.ts";
 import { oneByOne, OneByOneResult } from "./utils.ts";
 import { isSameDay } from "./deps/date-fns.ts";
-import { joinPageRoom } from "./deps/scrapbox-std.ts";
+import { joinPageRoom } from "./deps/scrapbox-websocket.ts";
 
 export interface PushTasksResult {
   /** 書き込み先の日付ページの日付 */ date: Date;

--- a/pushTasks.ts
+++ b/pushTasks.ts
@@ -2,7 +2,7 @@ import { TaskBlock, toString } from "./task.ts";
 import { format, toTitle } from "./diary.ts";
 import { oneByOne, OneByOneResult } from "./utils.ts";
 import { isSameDay } from "./deps/date-fns.ts";
-import { joinPageRoom } from "./deps/scrapbox.ts";
+import { joinPageRoom } from "./deps/scrapbox-std.ts";
 
 export interface PushTasksResult {
   /** 書き込み先の日付ページの日付 */ date: Date;


### PR DESCRIPTION
close [⬜takker99/takker-schedulerで使っているscrapbox-headless-scriptをscrapbox-userscript-stdに置き換える](https://scrapbox.io/takker/⬜takker99%2Ftakker-schedulerで使っているscrapbox-headless-scriptをscrapbox-userscript-stdに置き換える)