### PR TITLE
fix(scheduler): タスクリンクの復元に失敗している

### DIFF
--- a/workflow/DailySchedule.tsx
+++ b/workflow/DailySchedule.tsx
@@ -45,7 +45,7 @@ export const DailySchedule: FunctionComponent<
     [
       summary,
       ...events.map((event) =>
-        isLink(event) ? ` [${event.name}]` : ` ${event.name}`
+        isLink(event) ? ` [${event.title}]` : ` ${event.name}`
       ),
     ].join("\n"), [summary, events]);
 


### PR DESCRIPTION
close [✅️scheduler.tsxから予定をコピーした時、タスクリンクが元のリンクになっていない](https://scrapbox.io/takker/✅️scheduler.tsxから予定をコピーした時、タスクリンクが元のリンクになっていない)