### PR TITLE
feat(scheduler): wedgetはdefaultで閉じておく

### DIFF
--- a/workflow/weekly-calendar/mod.tsx
+++ b/workflow/weekly-calendar/mod.tsx
@@ -144,7 +144,7 @@ const App = ({ getController, projects, mainProject }: Props) => {
 
 const Wedget = ({ getController, projects, mainProject }: Props) => {
   // UIの開閉
-  const [closed, setClosed] = useState(false);
+  const [closed, setClosed] = useState(true);
   const open = useCallback(() => setClosed(false), []);
   const close = useCallback(() => setClosed(true), []);
   const toggle = useCallback(() => setClosed((closed) => !closed), []);


### PR DESCRIPTION
close [⬜️スマホで当日の予定をタイムラインに常時表示するUserScriptが表示されたままだと邪魔](https://scrapbox.io/takker/⬜️スマホで当日の予定をタイムラインに常時表示するUserScriptが表示されたままだと邪魔)