### PR TITLE
fix(scheduler): ページの書き換えでuseLines()を更新する

### DIFF
--- a/workflow/useLines.ts
+++ b/workflow/useLines.ts
@@ -22,12 +22,12 @@ const update = () => {
     clearInterval(timer);
     timer = undefined;
   }
-  const lines = takeInternalLines().map((line) => line.text);
   const project = scrapbox.Project.name;
   const title = scrapbox.Page.title ?? "";
   const key = toKey(project, title);
   if (!pages.has(key)) return;
 
+  const lines = takeInternalLines().map((line) => line.text);
   // 更新のタイミングの影響で、本文がまだ更新されていない可能性がある
   // その場合は`title`と本文先頭の文字列が一致するまで待機する
   timer = setInterval(() => {
@@ -42,7 +42,7 @@ const update = () => {
 let timer: undefined | number;
 {
   scrapbox.on("page:changed", () => {
-    if (update) scrapbox.off("lines:changed", update);
+    scrapbox.off("lines:changed", update);
 
     const project = scrapbox.Project.name;
     const title = scrapbox.Page.title ?? "";
@@ -62,7 +62,10 @@ const get = (project: string, title: string): string[] => {
         if (!result.ok) return [];
         const lines = result.value.lines.map((line) => line.text);
         emitChange(key, lines);
-        if (title === scrapbox.Page.title) {
+        if (
+          title === scrapbox.Page.title &&
+          !scrapbox.listeners("lines:changed").includes(update)
+        ) {
           scrapbox.on("lines:changed", update);
         }
       });


### PR DESCRIPTION
fix #205, which causes a memory leak