### PR TITLE
feat(scheduler): timeline-wedgetの幅を調整する

### DIFF
--- a/workflow/weekly-calendar/timegrid.css
+++ b/workflow/weekly-calendar/timegrid.css
@@ -133,8 +133,10 @@
     position: fixed;
     top: 60px;
     left: 10px;
-    max-width: 100px;
     max-height: calc(90vh - 60px);
+    max-width: 100px;
+    width: calc(100vw / 767 * 100 - 10px);
+    min-width: 60px;
     border: solid 1px #888;
     border-radius: 4px;
     display: flex;


### PR DESCRIPTION
close [✅️当日の予定をタイムラインに常時表示するUserScriptが#editorに被らないようにする](https://scrapbox.io/takker/✅️当日の予定をタイムラインに常時表示するUserScriptが%23editorに被らないようにする)

[当日の予定をタイムラインに常時表示するUserScriptの調整用UserCSS](https://scrapbox.io/takker/当日の予定をタイムラインに常時表示するUserScriptの調整用UserCSS)を使う前提